### PR TITLE
Update rcon-velocity-config.toml

### DIFF
--- a/templates/rcon-velocity-config.toml
+++ b/templates/rcon-velocity-config.toml
@@ -1,3 +1,4 @@
+rcon-host = "0.0.0.0"
 rcon-port = "${PORT}"
 rcon-password = "${PASSWORD}"
 rcon-colored = false


### PR DESCRIPTION
Set rcon-host to 0.0.0.0 to prevent defaulting to 127.0.0.1 (localhost), which would prevent RCON from communicating with other containers in the Docker network.