### PR TITLE
PaperMC API specification changes

### DIFF
--- a/scripts/run-bungeecord.sh
+++ b/scripts/run-bungeecord.sh
@@ -254,7 +254,7 @@ function getFromPaperMc() {
   fi
 
 
-  if ! jar=$(get --json-path=".downloads.application.name" "https://api.papermc.io/v2/projects/${project}/versions/${version}/builds/${buildId}"); then
+  if ! jar=$(get --json-path=".downloads.application.name" "https://api.papermc.io/v2/projects/${project}/versions/${version}/builds/${buildId}/"); then
     echo "ERROR: failed to lookup PaperMC download file from version=${version} build=${buildId}"
     exit 1
   fi


### PR DESCRIPTION
I'm not sure when it started, but
it seems that the API response changes depending on whether or not there is a “/” in the URL.

slash included
![image](https://github.com/user-attachments/assets/247f64b0-a087-4ead-bc28-ab3d6c751e25)

without slashes
![image](https://github.com/user-attachments/assets/c72e3a07-a078-455f-a96b-fa3242813c0b)
