### PR TITLE
Reduce layer size

### DIFF
--- a/build/install-packages.sh
+++ b/build/install-packages.sh
@@ -14,4 +14,4 @@ DEBIAN_FRONTEND=noninteractive \
     unzip \
     imagemagick
 
-apt-get clean
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When trying to push my image that uses this one as a base i encountered issues that the layer where it runs `instal-packages.sh` is too big. 

This change reduces the layer size enough to make that possible again.