### PR TITLE
Update MC_HELPER_VERSION to 1.54.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
 
 COPY templates/ /templates/
 
-ARG MC_HELPER_VERSION=1.50.2
+ARG MC_HELPER_VERSION=1.54.1
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1


### PR DESCRIPTION
Patched yaml will quote most strings to avoid misinterpretation of a mix of digits and non-digits.

For https://github.com/itzg/mc-image-helper/issues/712