### PR TITLE
Update README to clarify MINECRAFT_VERSION requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ healthy
 
   Dependency resolution can be adjusted by setting `MODRINTH_DOWNLOAD_DEPENDENCIES` to `none`, `optional`, or `required` (the default).
 
-  **NOTE** The variable `MINECRAFT_VERSION` must be set to the corresponding Minecraft version.
+> [!IMPORTANT]
+> The variable `MINECRAFT_VERSION` must be set to the corresponding Minecraft version, which would be the `VERSION` variable in a container running `itzg/minecraft-server`.
 
 * **ENABLE_RCON**
 


### PR DESCRIPTION
Clarified the requirement for setting the MINECRAFT_VERSION variable in the context of using itzg/minecraft-server.